### PR TITLE
Source code not building on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: cpp
 sudo: false
-branches:
-  only:
-    - master
 addons:
   apt:
     packages:
@@ -11,9 +8,11 @@ addons:
       - build-essential
       - libssl-dev
       - libsqlite3-dev
+      - zlib1g-dev
+      - protobuf-compiler
 script:
   - ./configure
-  - make doxygen-doc
+  - make
 after_success:
   - ssh-keyscan -H $HOSTNAME 2>&1 | tee -a $HOME/.ssh/known_hosts
   - openssl aes-256-cbc -K $encrypted_31fcab4e3357_key -iv $encrypted_31fcab4e3357_iv -in .travis.d/id-rsa.enc -out .travis.d/id-rsa -d


### PR DESCRIPTION
This PR originated from the 7th NDN International hackathon, our project was to create racket binding to this ndn-cpp. We noticed that missing dependencies (protobuf and zlib) caused the project to fail in the most obscure of ways, chewing 1/2 of our time. 

This PR ensures that 1) travis builds on every PR 2) all deps are present 3) it builds the actual source code and not just the docs.